### PR TITLE
Address comments on PR.

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1209,7 +1209,7 @@ class CustomActions(Resource):
 
 
 class LoginNodesImage(Resource):
-    """Represent the configuration of LoginNode Image."""
+    """Represent the Image configuration of LoginNodes."""
 
     def __init__(self, custom_ami: str):
         super().__init__()
@@ -1231,7 +1231,7 @@ class LoginNodesSsh(_BaseSsh):
 
 
 class LoginNodesNetworking(_BaseNetworking):
-    """Represent the networking configuration for the login node."""
+    """Represent the networking configuration for LoginNodes."""
 
     def __init__(
             self,
@@ -1270,7 +1270,7 @@ class LoginNodesPools(Resource):
 
 
 class LoginNodes(Resource):
-    """Represent the configuration of a LoginNodes."""
+    """Represent the configuration of LoginNodes."""
 
     def __init__(
             self,

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -752,7 +752,7 @@ class SchedulerPluginQueueNetworkingSchema(SlurmQueueNetworkingSchema):
 
 
 class BaseSshSchema(BaseSchema):
-    """Represent the schema of the BaseSsh."""
+    """Represent the schema of common Ssh parameters used by head and login nodes."""
     key_name = fields.Str(metadata={"update_policy": UpdatePolicy.UNSUPPORTED})
 
 
@@ -975,7 +975,7 @@ class QueueIamSchema(IamSchema):
 
 
 class LoginNodesIamSchema(BaseIamSchema):
-    """Represent the schema of IAM for LoginNode."""
+    """Represent the IAM schema of LoginNodes."""
 
     instance_profile = fields.Str(
         validate=validate.Regexp("^arn:.*:instance-profile/")
@@ -1286,7 +1286,7 @@ class HeadNodeSchema(BaseSchema):
 
 
 class LoginNodesImageSchema(BaseSchema):
-    """Represent the schema of the LoginNodeImage."""
+    """Represent the Image schema of LoginNodes."""
     custom_ami = fields.Str(validate=validate.Regexp(PCLUSTER_AMI_ID_REGEX))
 
     @post_load
@@ -1296,7 +1296,7 @@ class LoginNodesImageSchema(BaseSchema):
 
 
 class LoginNodesSshSchema(BaseSshSchema):
-    """Represent the schema of the LoginNodeSsh."""
+    """Represent the Ssh schema of LoginNodes."""
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate resource."""
@@ -1304,7 +1304,7 @@ class LoginNodesSshSchema(BaseSshSchema):
 
 
 class LoginNodesNetworkingSchema(BaseNetworkingSchema):
-    """Represent the schema of the LoginNodeNetworking."""
+    """Represent the networking schema of LoginNodes."""
     subnet_id = fields.Str(required=True)
 
     @post_load
@@ -1330,7 +1330,7 @@ class LoginNodesPoolsSchema(BaseSchema):
 
 
 class LoginNodesSchema(BaseSchema):
-    """Represent the schema of the LoginNodes."""
+    """Represent the schema of LoginNodes."""
     pools = fields.Nested(
         LoginNodesPoolsSchema,
         many=True,

--- a/cli/src/pcluster/validators/networking_validators.py
+++ b/cli/src/pcluster/validators/networking_validators.py
@@ -206,6 +206,6 @@ class AvailabilityZoneValidator(Validator):
         if AWSApi.instance().ec2.get_subnet_avail_zone(login_node_subnet_id) != \
                 AWSApi.instance().ec2.get_subnet_avail_zone(head_node_subnet_id):
             self._add_failure(
-                "LoginNode Networking SubnetId must be in the same availability zone as the HeadNode.",
+                "Login nodes and head node must be in the same availability zone",
                 FailureLevel.ERROR,
             )

--- a/cli/tests/pcluster/config/dummy_cluster_config.py
+++ b/cli/tests/pcluster/config/dummy_cluster_config.py
@@ -23,7 +23,7 @@ from pcluster.config.cluster_config import (
     Dcv,
     HeadNode,
     HeadNodeNetworking,
-    HeadNodeAndQueueIam,
+    Iam,
     Image,
     Imds,
     Proxy,
@@ -47,12 +47,12 @@ from pcluster.config.cluster_config import (
     SlurmQueue,
     SlurmQueueNetworking,
     SlurmScheduling,
-    Ssh,
+    HeadNodeSsh,
     Tag,
     LoginNodes,
-    LoginNodePool,
-    LoginNodeSsh,
-    LoginNodeNetworking,
+    LoginNodesPools,
+    LoginNodesSsh,
+    LoginNodesNetworking,
 )
 from pcluster.config.common import Resource
 
@@ -126,7 +126,7 @@ def dummy_head_node(mocker):
     head_node_networking.additional_security_groups = ["additional-dummy-sg-1"]
     head_node_dcv = Dcv(enabled=True, port=1024)
     head_node_imds = Imds(secured=True)
-    ssh = Ssh(key_name="test")
+    ssh = HeadNodeSsh(key_name="test")
 
     custom_actions = CustomActions(
         on_node_start=[
@@ -153,7 +153,7 @@ def dummy_slurm_cluster_config(mocker):
     """Generate dummy cluster."""
     image = Image(os="alinux2")
     head_node = dummy_head_node(mocker)
-    queue_iam = HeadNodeAndQueueIam(
+    queue_iam = Iam(
         s3_access=[
             S3Access("dummy-readonly-bucket", enable_write_access=True),
             S3Access("dummy-readwrite-bucket"),
@@ -170,12 +170,12 @@ def dummy_slurm_cluster_config(mocker):
     ]
     scheduling = SlurmScheduling(queues=queues)
     pools = [
-        LoginNodePool(
+        LoginNodesPools(
             name="loginnode1",
             instance_type="t2.micro",
-            networking=LoginNodeNetworking(subnet_id="subnet-12345678"),
+            networking=LoginNodesNetworking(subnet_id="subnet-12345678"),
             count=1,
-            ssh=LoginNodeSsh(key_name="validkeyname")
+            ssh=LoginNodesSsh(key_name="validkeyname")
         )
     ]
     login_nodes = LoginNodes(pools=pools)
@@ -235,7 +235,7 @@ def dummy_scheduler_plugin_cluster_config(mocker):
     """Generate dummy cluster."""
     image = Image(os="alinux2")
     head_node = dummy_head_node(mocker)
-    queue_iam = HeadNodeAndQueueIam(
+    queue_iam = Iam(
         s3_access=[
             S3Access("dummy-readonly-bucket", enable_write_access=True),
             S3Access("dummy-readwrite-bucket"),

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -1,5 +1,4 @@
 import pytest
-import getpass
 from assertpy import assert_that
 
 from pcluster.aws.aws_resources import InstanceTypeInfo
@@ -28,10 +27,10 @@ from pcluster.config.cluster_config import (
     SlurmScheduling,
     SlurmSettings,
     Tag,
-    LoginNodePool,
-    LoginNodeImage,
-    LoginNodeNetworking,
-    LoginNodeSsh,
+    LoginNodesPools,
+    LoginNodesImage,
+    LoginNodesNetworking,
+    LoginNodesSsh,
     LoginNodes,
 )
 
@@ -501,12 +500,12 @@ class TestBaseClusterConfig:
         assert_that(queue.get_tags()).is_equal_to(tags)
 
     def test_login_node_pool_default_value(self):
-        login_node_pool = LoginNodePool(
+        login_node_pool = LoginNodesPools(
             name="test_pool2",
             instance_type="t3.xlarge",
-            image=LoginNodeImage(custom_ami="ami-0222222222222222"),
-            networking=LoginNodeNetworking(subnet_id="subnet-0222222222222222"),
-            ssh=LoginNodeSsh(key_name="mykey"),
+            image=LoginNodesImage(custom_ami="ami-0222222222222222"),
+            networking=LoginNodesNetworking(subnet_id="subnet-0222222222222222"),
+            ssh=LoginNodesSsh(key_name="mykey"),
         )
 
         login_nodes = LoginNodes(pools=[login_node_pool])

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -15,7 +15,6 @@ import re
 from abc import ABC, abstractmethod
 from datetime import datetime
 
-import pyperclip
 import pytest
 import yaml
 from assertpy import assert_that
@@ -102,7 +101,6 @@ def _assert_config_snapshot(config, expected_full_config_path):
     cluster_name = "test_cluster"
     full_config = ClusterSchema(cluster_name).dump(config)
     full_config_yaml = yaml.dump(full_config)
-    pyperclip.copy(full_config_yaml)
 
     with open(expected_full_config_path, "r") as expected_full_config_file:
         expected_full_config = expected_full_config_file.read()

--- a/cli/tests/pcluster/validators/test_networking_validators.py
+++ b/cli/tests/pcluster/validators/test_networking_validators.py
@@ -273,7 +273,7 @@ def test_lambda_functions_vpc_config_validator(
                 "subnet-09ce1152ecf4b0f52",
                 "us-east-1",
                 "us-west-2",
-                "LoginNode Networking SubnetId must be in the same availability zone as the HeadNode.",
+                "Login nodes and head node must be in the same availability zone",
         ),
 
         # Test case for same availability zones


### PR DESCRIPTION
    * Delete some codes not being used.
    * Add BaseIam related classes.
        * Make LoginNodesIam and HeadNodeIam inherit from BaseIam.
    * Rename the LoginNodes related class with 's'.
    * Add unit test to confirm that the instance profile and instance role cannot be used together.
    * Change some error messages
        * "Only one pool can be specified when using login nodes."
        * "Login nodes and head node must be in the same availability zone".

