### PR TITLE
Split 2 too complex functions, modify count validator, delete unused import.

### DIFF
--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1323,7 +1323,7 @@ class LoginNodesPoolsSchema(BaseSchema):
     instance_type = fields.Str(required=True)
     image = fields.Nested(LoginNodesImageSchema)
     networking = fields.Nested(LoginNodesNetworkingSchema, required=True)
-    count = fields.Int(required=True, validate=validate.Range(min=1))
+    count = fields.Int(required=True, validate=validate.Range(min=0))
     ssh = fields.Nested(LoginNodesSshSchema, required=True)
     iam = fields.Nested(LoginNodesIamSchema)
 

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -3,7 +3,7 @@ from typing import Dict
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
-from aws_cdk.core import CfnTag, NestedStack, Stack
+from aws_cdk.core import NestedStack, Stack
 from constructs import Construct
 
 from pcluster.config.cluster_config import LoginNodesPools, SlurmClusterConfig

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -688,8 +688,8 @@ def test_login_node_custom_ami_validator(custom_ami, expected_message):
     [
         (1, None),
         (10, None),
-        (0, "Must be greater than or equal to 1."),
-        (-5, "Must be greater than or equal to 1."),
+        (0, None),
+        (-5, "Must be greater than or equal to 0."),
     ],
 )
 def test_login_node_pool_count_validator(count, expected_message):


### PR DESCRIPTION
Split _add_security_groups function and _add_inbounds_to_managed_security_groups function.
Modify login nodes pools count validator to min=0. 
Delete unused import.