### PR TITLE
Address comments in the PR

### DIFF
--- a/cli/src/pcluster/config/cluster_config.py
+++ b/cli/src/pcluster/config/cluster_config.py
@@ -1256,8 +1256,8 @@ class LoginNodesNetworking(_BaseNetworking):
         return AWSApi.instance().ec2.get_subnet_avail_zone(self.subnet_id)
 
 
-class LoginNodesPools(Resource):
-    """Represent the configuration of a LoginNodePool."""
+class LoginNodesPool(Resource):
+    """Represent the configuration of a LoginNodesPool."""
 
     def __init__(
         self,
@@ -1281,12 +1281,12 @@ class LoginNodesPools(Resource):
 
     @property
     def instance_profile(self):
-        """Return the IAM instance profile for login node, if set."""
+        """Return the IAM instance profile for login nodes, if set."""
         return self.iam.instance_profile if self.iam else None
 
     @property
     def instance_role(self):
-        """Return the IAM role for login node, if set."""
+        """Return the IAM role for login nodes, if set."""
         return self.iam.instance_role if self.iam else None
 
     def _register_validators(self, context: ValidatorContext = None):  # noqa: D102 #pylint: disable=unused-argument
@@ -1298,7 +1298,7 @@ class LoginNodes(Resource):
 
     def __init__(
         self,
-        pools: List[LoginNodesPools],
+        pools: List[LoginNodesPool],
         **kwargs,
     ):
         super().__init__(**kwargs)

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -71,7 +71,7 @@ from pcluster.config.cluster_config import (
     LoginNodesIam,
     LoginNodesImage,
     LoginNodesNetworking,
-    LoginNodesPools,
+    LoginNodesPool,
     LoginNodesSsh,
     LogRotation,
     Logs,
@@ -1316,8 +1316,8 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
         return LoginNodesNetworking(**data)
 
 
-class LoginNodesPoolsSchema(BaseSchema):
-    """Represent the schema of the LoginNodePool."""
+class LoginNodesPoolSchema(BaseSchema):
+    """Represent the schema of the LoginNodesPool."""
 
     name = fields.Str(required=True)
     instance_type = fields.Str(required=True)
@@ -1330,14 +1330,14 @@ class LoginNodesPoolsSchema(BaseSchema):
     @post_load
     def make_resource(self, data, **kwargs):
         """Generate resource."""
-        return LoginNodesPools(**data)
+        return LoginNodesPool(**data)
 
 
 class LoginNodesSchema(BaseSchema):
     """Represent the schema of LoginNodes."""
 
     pools = fields.Nested(
-        LoginNodesPoolsSchema,
+        LoginNodesPoolSchema,
         many=True,
         required=True,
         validate=validate.Length(equal=1, error="Only one pool can be specified when using login nodes."),

--- a/cli/src/pcluster/templates/cdk_builder_utils.py
+++ b/cli/src/pcluster/templates/cdk_builder_utils.py
@@ -28,7 +28,7 @@ from pcluster.config.cluster_config import (
     BaseComputeResource,
     BaseQueue,
     HeadNode,
-    LoginNodesPools,
+    LoginNodesPool,
     SharedStorageType,
     SlurmClusterConfig,
     SlurmComputeResource,
@@ -159,7 +159,7 @@ def get_custom_tags(config: Union[BaseClusterConfig, SlurmQueue, SlurmComputeRes
 def get_default_instance_tags(
     stack_name: str,
     config: BaseClusterConfig,
-    node: Union[HeadNode, LoginNodesPools, BaseComputeResource],
+    node: Union[HeadNode, LoginNodesPool, BaseComputeResource],
     node_type: str,
     shared_storage_infos: dict,
     raw_dict: bool = False,
@@ -264,7 +264,7 @@ def get_queue_security_groups_full(managed_compute_security_group: ec2.CfnSecuri
 
 def get_login_nodes_security_groups_full(
     managed_login_security_group: ec2.CfnSecurityGroup,
-    pool: LoginNodesPools,
+    pool: LoginNodesPool,
 ):
     """Return full security groups to be used for the login node, default plus additional ones."""
     login_nodes_security_groups = []
@@ -360,7 +360,7 @@ class NodeIamResourcesBase(Construct):
         scope: Construct,
         id: str,
         config: BaseClusterConfig,
-        node: Union[HeadNode, BaseQueue, LoginNodesPools],
+        node: Union[HeadNode, BaseQueue, LoginNodesPool],
         shared_storage_infos: dict,
         name: str,
     ):
@@ -372,7 +372,7 @@ class NodeIamResourcesBase(Construct):
 
     def _add_role_and_policies(
         self,
-        node: Union[HeadNode, BaseQueue, LoginNodesPools],
+        node: Union[HeadNode, BaseQueue, LoginNodesPool],
         shared_storage_infos: dict,
         name: str,
     ):
@@ -415,7 +415,7 @@ class NodeIamResourcesBase(Construct):
             instance_profile_name=instance_profile_name,
         ).ref
 
-    def _add_node_role(self, node: Union[HeadNode, BaseQueue, LoginNodesPools], name: str):
+    def _add_node_role(self, node: Union[HeadNode, BaseQueue, LoginNodesPool], name: str):
         role_path, role_name = add_cluster_iam_resource_prefix(
             self._config.cluster_name, self._config, name, iam_type="AWS::IAM::Role"
         )
@@ -477,7 +477,7 @@ class NodeIamResourcesBase(Construct):
         except AttributeError:
             return False
 
-    def _condition_create_s3_access_policies(self, node: Union[HeadNode, BaseQueue, LoginNodesPools]):
+    def _condition_create_s3_access_policies(self, node: Union[HeadNode, BaseQueue, LoginNodesPool]):
         return node.iam and node.iam.s3_access
 
     def _add_custom_cookbook_policies_to_role(self, role_ref: str, name: str):
@@ -510,7 +510,7 @@ class NodeIamResourcesBase(Construct):
         )
 
     def _add_s3_access_policies_to_role(
-        self, node: Union[HeadNode, BaseQueue, LoginNodesPools], role_ref: str, name: str
+        self, node: Union[HeadNode, BaseQueue, LoginNodesPool], role_ref: str, name: str
     ):
         """Attach S3 policies to given role."""
         read_only_s3_resources = []
@@ -574,7 +574,7 @@ class HeadNodeIamResources(NodeIamResourcesBase):
         scope: Construct,
         id: str,
         config: BaseClusterConfig,
-        node: Union[HeadNode, BaseQueue, LoginNodesPools],
+        node: Union[HeadNode, BaseQueue, LoginNodesPool],
         shared_storage_infos: dict,
         name: str,
         cluster_bucket: S3Bucket,
@@ -875,7 +875,7 @@ class ComputeNodeIamResources(NodeIamResourcesBase):
         scope: Construct,
         id: str,
         config: BaseClusterConfig,
-        node: Union[HeadNode, BaseQueue, LoginNodesPools],
+        node: Union[HeadNode, BaseQueue, LoginNodesPool],
         shared_storage_infos: dict,
         name: str,
     ):
@@ -915,7 +915,7 @@ class LoginNodesIamResources(NodeIamResourcesBase):
         scope: Construct,
         id: str,
         config: BaseClusterConfig,
-        node: LoginNodesPools,
+        node: LoginNodesPool,
         shared_storage_infos: dict,
         name: str,
     ):

--- a/cli/src/pcluster/templates/cluster_stack.py
+++ b/cli/src/pcluster/templates/cluster_stack.py
@@ -415,6 +415,7 @@ class ClusterCdkStack:
 
     def _add_login_nodes_resources(self):
         """Add Login Nodes related resources."""
+        self.login_nodes_stack = None
         if self._condition_is_slurm() and self.config.login_nodes:
             self.login_nodes_stack = LoginNodesStack(
                 scope=self.stack,
@@ -425,6 +426,8 @@ class ClusterCdkStack:
                 shared_storage_attributes=self.shared_storage_attributes,
                 login_security_group=self._login_security_group,
             )
+            # Add dependency on the Head Node construct
+            self.login_nodes_stack.node.add_dependency(self.head_node_instance)
 
     def _add_cleanup_resources_lambda(self):
         """Create Lambda cleanup resources function and its role."""

--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -6,7 +6,7 @@ from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk.core import NestedStack, Stack
 from constructs import Construct
 
-from pcluster.config.cluster_config import LoginNodesPools, SlurmClusterConfig
+from pcluster.config.cluster_config import LoginNodesPool, SlurmClusterConfig
 from pcluster.templates.cdk_builder_utils import (
     CdkLaunchTemplateBuilder,
     LoginNodesIamResources,
@@ -49,15 +49,11 @@ class LoginNodesStack(NestedStack):
 
     def _add_resources(self):
         # get unique login nodes pools subnet id
-        subnet_ids = set()
-        for login_nodes_pool in self._login_nodes.pools:
-            subnet_ids.add(login_nodes_pool.networking.subnet_id)
+        subnet_ids = set(pool.networking.subnet_id for pool in self._login_nodes.pools)
         self._pools_subnet_ids = list(subnet_ids)
 
         # get unique login nodes pools availability_zone
-        availability_zones = set()
-        for login_nodes_pool in self._login_nodes.pools:
-            availability_zones.add(login_nodes_pool.networking.availability_zone)
+        availability_zones = set(pool.networking.availability_zone for pool in self._login_nodes.pools)
         self._pools_availability_zones = list(availability_zones)
 
         self._vpc = ec2.Vpc.from_vpc_attributes(
@@ -101,7 +97,7 @@ class LoginNodesStack(NestedStack):
 
     def _add_login_nodes_pool_launch_template(
         self,
-        login_nodes_pool: LoginNodesPools,
+        login_nodes_pool: LoginNodesPool,
         login_nodes_pool_lt_security_groups,
         login_nodes_instance_profiles,
     ):
@@ -195,7 +191,7 @@ class LoginNodesStack(NestedStack):
 
     def _add_login_nodes_pool_auto_scaling_group(
         self,
-        login_nodes_pool: LoginNodesPools,
+        login_nodes_pool: LoginNodesPool,
         login_nodes_target_group,
     ):
         launch_template_specification = autoscaling.CfnAutoScalingGroup.LaunchTemplateSpecificationProperty(

--- a/cli/tests/pcluster/config/dummy_cluster_config.py
+++ b/cli/tests/pcluster/config/dummy_cluster_config.py
@@ -29,7 +29,7 @@ from pcluster.config.cluster_config import (
     Imds,
     LoginNodes,
     LoginNodesNetworking,
-    LoginNodesPools,
+    LoginNodesPool,
     LoginNodesSsh,
     Proxy,
     Raid,
@@ -170,7 +170,7 @@ def dummy_slurm_cluster_config(mocker):
     ]
     scheduling = SlurmScheduling(queues=queues)
     pools = [
-        LoginNodesPools(
+        LoginNodesPool(
             name="loginnode1",
             instance_type="t2.micro",
             networking=LoginNodesNetworking(subnet_id="subnet-12345678"),

--- a/cli/tests/pcluster/config/test_cluster_config.py
+++ b/cli/tests/pcluster/config/test_cluster_config.py
@@ -18,7 +18,7 @@ from pcluster.config.cluster_config import (
     LoginNodes,
     LoginNodesImage,
     LoginNodesNetworking,
-    LoginNodesPools,
+    LoginNodesPool,
     LoginNodesSsh,
     PlacementGroup,
     QueueImage,
@@ -500,7 +500,7 @@ class TestBaseClusterConfig:
         assert_that(queue.get_tags()).is_equal_to(tags)
 
     def test_login_node_pool_default_value(self):
-        login_node_pool = LoginNodesPools(
+        login_node_pool = LoginNodesPool(
             name="test_pool2",
             instance_type="t3.xlarge",
             image=LoginNodesImage(custom_ami="ami-0222222222222222"),

--- a/cli/tests/pcluster/schemas/test_schema_validators.py
+++ b/cli/tests/pcluster/schemas/test_schema_validators.py
@@ -33,7 +33,7 @@ from pcluster.schemas.cluster_schema import (
     ImageSchema,
     LoginNodesIamSchema,
     LoginNodesImageSchema,
-    LoginNodesPoolsSchema,
+    LoginNodesPoolSchema,
     LoginNodesSchema,
     QueueEphemeralVolumeSchema,
     QueueNetworkingSchema,
@@ -694,7 +694,7 @@ def test_login_node_custom_ami_validator(custom_ami, expected_message):
 )
 def test_login_node_pool_count_validator(count, expected_message):
     _validate_and_assert_error(
-        LoginNodesPoolsSchema(),
+        LoginNodesPoolSchema(),
         {
             "Name": "validname",
             "InstanceType": "t2.micro",


### PR DESCRIPTION
Change LoginNodePool instead of LoginNodesPools, add dependency on the Head Node construct in _add_login_nodes_resources() function, using set comprehension to increase the readability of the code.