### PR TITLE
Add Unit Test for ASG, NLB, TG, NLB listener. Add a unit test to conf…

### DIFF
--- a/cli/src/pcluster/aws/ec2.py
+++ b/cli/src/pcluster/aws/ec2.py
@@ -490,16 +490,55 @@ class Ec2Client(Boto3Client):
 
     @AWSExceptionHandler.handle_client_exception
     def describe_route_tables(self, filters=None):
-        """Describe EC2 route tables."""
+        """
+        Describe EC2 route tables.
+
+        sample output:
+        [
+            {
+                "Associations": [
+                    {
+                        "Main": False,
+                        "RouteTableAssociationId": "rtbassoc-12345678901234567",
+                        "RouteTableId": "rtb-12345678901234567",
+                        "SubnetId": "subnet-12345678901234567",
+                        "AssociationState": {"State": "associated"},
+                    }
+                ],
+                "PropagatingVgws": [],
+                "RouteTableId": "rtb-12345678901234567",
+                "Routes": [
+                    {
+                        "DestinationCidrBlock": "10.0.0.0/16",
+                        "GatewayId": "local",
+                        "Origin": "CreateRouteTable",
+                        "State": "active",
+                    },
+                    {
+                        "DestinationCidrBlock": "0.0.0.0/0",
+                        "GatewayId": "igw-12345678901234567",
+                        "Origin": "CreateRoute",
+                        "State": "active",
+                    },
+                ],
+                "Tags": [
+                    {"Key": "aws:cloudformation:logical-id", "Value": "RouteTablePublic"},
+                    ...
+                ],
+                "VpcId": "vpc-12345678901234567",
+                "OwnerId": "123456789012"
+            }
+        ]
+        :param filters: The filters to apply when describing the route tables.
+        :return: The route tables that match the filters.
+        """
         kwargs = {"Filters": filters} if filters else {}
-        return self._paginate_results(self._client.describe_route_tables, **kwargs)
+        return list(self._paginate_results(self._client.describe_route_tables, **kwargs))
 
     @AWSExceptionHandler.handle_client_exception
     def is_subnet_public(self, subnet_id):
         """Check if a subnet is public."""
-        route_tables = list(
-            self.describe_route_tables(filters=[{"Name": "association.subnet-id", "Values": [subnet_id]}])
-        )
+        route_tables = self.describe_route_tables(filters=[{"Name": "association.subnet-id", "Values": [subnet_id]}])
         if not route_tables:
             return False
 

--- a/cli/src/pcluster/schemas/cluster_schema.py
+++ b/cli/src/pcluster/schemas/cluster_schema.py
@@ -1311,7 +1311,7 @@ class LoginNodesNetworkingSchema(BaseNetworkingSchema):
     subnet_ids = fields.List(
         fields.Str(validate=get_field_validator("subnet_id")),
         required=True,
-        validate=validate.Length(equal=1, error="In MVP, only one subnet_id can be specified."),
+        validate=validate.Length(equal=1, error="Only one subnet can be associated with a login node pool"),
     )
 
     @post_load

--- a/cli/tests/pcluster/templates/test_cluster_stack.py
+++ b/cli/tests/pcluster/templates/test_cluster_stack.py
@@ -493,6 +493,29 @@ class EbsLTAssertion(LTPropertyAssertion):
             assert_that(ebs_optimized).is_none()
 
 
+def get_generated_template_and_cdk_assets(
+    mocker,
+    config_file_name,
+    test_datadir,
+):
+    mock_aws_api(mocker, mock_instance_type_info=False)
+
+    mocker.patch(
+        "pcluster.aws.ec2.Ec2Client.get_instance_type_info",
+        side_effect=_mock_instance_type_info,
+    )
+    # mock bucket initialization parameters
+    mock_bucket(mocker)
+    mock_bucket_object_utils(mocker)
+
+    input_yaml, cluster = load_cluster_model_from_yaml(config_file_name, test_datadir)
+    generated_template, cdk_assets = CDKTemplateBuilder().build_cluster_template(
+        cluster_config=cluster, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    )
+
+    return generated_template, cdk_assets
+
+
 @pytest.mark.parametrize(
     "config_file_name, lt_assertions",
     [
@@ -520,19 +543,10 @@ def test_compute_launch_template_properties(
     lt_assertions,
     test_datadir,
 ):
-    mock_aws_api(mocker, mock_instance_type_info=False)
-
-    mocker.patch(
-        "pcluster.aws.ec2.Ec2Client.get_instance_type_info",
-        side_effect=_mock_instance_type_info,
-    )
-    # mock bucket initialization parameters
-    mock_bucket(mocker)
-    mock_bucket_object_utils(mocker)
-
-    input_yaml, cluster = load_cluster_model_from_yaml(config_file_name, test_datadir)
-    generated_template, cdk_assets = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=cluster, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    generated_template, cdk_assets = get_generated_template_and_cdk_assets(
+        mocker,
+        config_file_name,
+        test_datadir,
     )
 
     asset_content = get_asset_content_with_resource_name(cdk_assets, "LaunchTemplate64e1c3597ca4c326")
@@ -585,24 +599,132 @@ def test_login_nodes_launch_template_properties(
     lt_assertions,
     test_datadir,
 ):
-    mock_aws_api(mocker, mock_instance_type_info=False)
-
-    mocker.patch(
-        "pcluster.aws.ec2.Ec2Client.get_instance_type_info",
-        side_effect=_mock_instance_type_info,
-    )
-    # mock bucket initialization parameters
-    mock_bucket(mocker)
-    mock_bucket_object_utils(mocker)
-
-    input_yaml, cluster = load_cluster_model_from_yaml(config_file_name, test_datadir)
-    generated_template, cdk_assets = CDKTemplateBuilder().build_cluster_template(
-        cluster_config=cluster, bucket=dummy_cluster_bucket(), stack_name="clustername"
+    generated_template, cdk_assets = get_generated_template_and_cdk_assets(
+        mocker,
+        config_file_name,
+        test_datadir,
     )
 
     asset_content = get_asset_content_with_resource_name(cdk_assets, "LaunchTemplate64e1c3597ca4c326")
     for lt_assertion in lt_assertions:
         lt_assertion.assert_lt_properties(asset_content, "LaunchTemplate64e1c3597ca4c326")
+
+
+class AutoScalingGroupAssertion:
+    def __init__(self, min_size: int, max_size: int, desired_capacity: int):
+        self.min_size = min_size
+        self.max_size = max_size
+        self.desired_capacity = desired_capacity
+
+    def assert_asg_properties(self, template, resource_name: str):
+        resource = template["Resources"][resource_name]
+        assert resource["Type"] == "AWS::AutoScaling::AutoScalingGroup"
+        properties = resource["Properties"]
+        assert int(properties["MinSize"]) == self.min_size
+        assert int(properties["MaxSize"]) == self.max_size
+        assert int(properties["DesiredCapacity"]) == self.desired_capacity
+
+
+class NetworkLoadBalancerAssertion:
+    def __init__(self, expected_vpc_id: str, expected_internet_facing: bool):
+        self.expected_vpc_id = expected_vpc_id
+        self.expected_internet_facing = expected_internet_facing
+
+    def assert_nlb_properties(self, template, resource_name: str):
+        resource = template["Resources"][resource_name]
+        assert resource["Type"] == "AWS::ElasticLoadBalancingV2::LoadBalancer"
+        properties = resource["Properties"]
+        assert properties["Type"] == "network"
+        assert properties["Subnets"][0] == self.expected_vpc_id
+        assert properties["Scheme"] == ("internet-facing" if self.expected_internet_facing else "internal")
+
+
+class TargetGroupAssertion:
+    def __init__(self, expected_health_check: str, expected_port: int, expected_protocol: str):
+        self.expected_health_check = expected_health_check
+        self.expected_port = expected_port
+        self.expected_protocol = expected_protocol
+
+    def assert_tg_properties(self, template, resource_name: str):
+        resource = template["Resources"][resource_name]
+        assert resource["Type"] == "AWS::ElasticLoadBalancingV2::TargetGroup"
+        properties = resource["Properties"]
+        assert properties["HealthCheckProtocol"] == self.expected_health_check
+        assert int(properties["Port"]) == self.expected_port
+        assert properties["Protocol"] == self.expected_protocol
+
+
+class NetworkLoadBalancerListenerAssertion:
+    def __init__(self, expected_port: int, expected_protocol: str):
+        self.expected_port = expected_port
+        self.expected_protocol = expected_protocol
+
+    def assert_nlb_listener_properties(self, template, resource_name: str):
+        resource = template["Resources"][resource_name]
+        assert resource["Type"] == "AWS::ElasticLoadBalancingV2::Listener"
+        properties = resource["Properties"]
+        assert int(properties["Port"]) == self.expected_port
+        assert properties["Protocol"] == self.expected_protocol
+
+
+@pytest.mark.parametrize(
+    "config_file_name, lt_assertions",
+    [
+        (
+            "test-login-nodes-stack.yaml",
+            [
+                AutoScalingGroupAssertion(min_size=2, max_size=2, desired_capacity=2),
+                NetworkLoadBalancerAssertion(expected_vpc_id="subnet-12345678", expected_internet_facing=True),
+                TargetGroupAssertion(expected_health_check="TCP", expected_port=22, expected_protocol="TCP"),
+                NetworkLoadBalancerListenerAssertion(expected_port=22, expected_protocol="TCP"),
+            ],
+        ),
+    ],
+)
+def test_login_nodes_traffic_management_resources_values_properties(
+    mocker,
+    config_file_name,
+    lt_assertions,
+    test_datadir,
+):
+    generated_template, cdk_assets = get_generated_template_and_cdk_assets(
+        mocker,
+        config_file_name,
+        test_datadir,
+    )
+
+    asset_content_asg = get_asset_content_with_resource_name(
+        cdk_assets, "Pooltestloginnodespool1Pooltestloginnodespool1AutoScalingGroup41053D91"
+    )
+    asset_content_nlb = get_asset_content_with_resource_name(
+        cdk_assets, "Pooltestloginnodespool1testloginnodespool1LoadBalancer18C3DA82"
+    )
+    asset_content_target_group = get_asset_content_with_resource_name(
+        cdk_assets, "Pooltestloginnodespool1testloginnodespool1TargetGroupD150DBF2"
+    )
+    asset_content_nlb_listener = get_asset_content_with_resource_name(
+        cdk_assets,
+        "Pooltestloginnodespool1testloginnodespool1LoadBalancerLoginNodesListenertestloginnodespool1727E619B",
+    )
+
+    for lt_assertion in lt_assertions:
+        if isinstance(lt_assertion, AutoScalingGroupAssertion):
+            lt_assertion.assert_asg_properties(
+                asset_content_asg, "Pooltestloginnodespool1Pooltestloginnodespool1AutoScalingGroup41053D91"
+            )
+        elif isinstance(lt_assertion, NetworkLoadBalancerAssertion):
+            lt_assertion.assert_nlb_properties(
+                asset_content_nlb, "Pooltestloginnodespool1testloginnodespool1LoadBalancer18C3DA82"
+            )
+        elif isinstance(lt_assertion, TargetGroupAssertion):
+            lt_assertion.assert_tg_properties(
+                asset_content_target_group, "Pooltestloginnodespool1testloginnodespool1TargetGroupD150DBF2"
+            )
+        elif isinstance(lt_assertion, NetworkLoadBalancerListenerAssertion):
+            lt_assertion.assert_nlb_listener_properties(
+                asset_content_nlb_listener,
+                "Pooltestloginnodespool1testloginnodespool1LoadBalancerLoginNodesListenertestloginnodespool1727E619B",
+            )
 
 
 @pytest.mark.parametrize(

--- a/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_traffic_management_resources_values_properties/test-login-nodes-stack.yaml
+++ b/cli/tests/pcluster/templates/test_cluster_stack/test_login_nodes_traffic_management_resources_values_properties/test-login-nodes-stack.yaml
@@ -1,0 +1,31 @@
+Region: eu-west-1
+Image:
+  Os: alinux2
+LoginNodes:
+  Pools:
+  - Name: testloginnodespool1
+    InstanceType: t2.micro
+    Count: 2
+    Networking:
+      SubnetIds:
+      - subnet-12345678
+    Ssh:
+      KeyName: ec2-key-name
+HeadNode:
+  InstanceType: t2.micro
+  Networking:
+    SubnetId: subnet-12345678
+  Ssh:
+    KeyName: ec2-key-name
+Scheduling:
+  Scheduler: slurm
+  SlurmQueues:
+  - Name: queue1
+    ComputeResources:
+    - Name: testcomputeresource
+      InstanceType: c4.xlarge
+      MinCount: 0
+      MaxCount: 10
+    Networking:
+      SubnetIds:
+      - subnet-12345678


### PR DESCRIPTION
- Add Unit Test for ASG, NLB, TG, NLB listener. Add a unit test to confirm is_subnet_public function assigns the correct subnet visibility (private/public) based on mocked route tables. 
- Add a sample/snippet output of the describe_route_tables call in the docstring of this function for better documentation. 
- Create a new class inherit from _BaseNetworking, to avoid code duplicates. 
- Use Sets for login_nodes_subnet_ids and compute_subnet_ids function to perform operation for better performance. 
- Change error message.