### PR TITLE
remove the wrongly lambda function and related code like get_iam_role…

### DIFF
--- a/cli/src/pcluster/templates/login_nodes_stack.py
+++ b/cli/src/pcluster/templates/login_nodes_stack.py
@@ -3,11 +3,7 @@ from typing import Dict
 from aws_cdk import aws_autoscaling as autoscaling
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
-from aws_cdk import aws_iam as iam
-from aws_cdk import aws_lambda as _lambda
-from aws_cdk import aws_sns as sns
-from aws_cdk import aws_sns_subscriptions as subscriptions
-from aws_cdk.core import CfnTag, Construct, Duration, Fn, NestedStack, Stack
+from aws_cdk.core import CfnTag, Construct, Fn, NestedStack, Stack
 
 from pcluster.config.cluster_config import LoginNodesPool, SlurmClusterConfig
 from pcluster.constants import PCLUSTER_LOGIN_NODES_POOL_NAME_TAG
@@ -61,65 +57,6 @@ class Pool(Construct):
 
         self._launch_template = self._add_login_nodes_pool_launch_template()
         self._add_login_nodes_pool_auto_scaling_group()
-
-    def _add_lifecycle_hook_lambda(self):
-        """Create a Lambda function to handle the ASG lifecycle hook."""
-        lifecycle_hook_function = _lambda.Function(
-            self,
-            "LifecycleHookFunction",
-            code=_lambda.Code.from_inline(
-                """
-import json
-import boto3
-import time
-import os
-
-def handler(event, context):
-    asg = boto3.client('autoscaling')
-
-    message = json.loads(event['Records'][0]['Sns']['Message'])
-    lifecycle_hook_name = message['LifecycleHookName']
-    ec2_instance_id = message['EC2InstanceId']
-    asg_group_name = message['AutoScalingGroupName']
-    lifecycle_action_token = message['LifecycleActionToken']
-
-    gracetime = int(os.environ['GRACETIME']) # read gracetime from environment variable
-
-    try:
-        time.sleep(gracetime)
-
-        # tell ASG to complete the lifecycle action so it can terminate the instance
-        asg.complete_lifecycle_action(
-            LifecycleHookName=lifecycle_hook_name,
-            AutoScalingGroupName=asg_group_name,
-            LifecycleActionResult='CONTINUE',
-            InstanceId=ec2_instance_id,
-            LifecycleActionToken=lifecycle_action_token
-        )
-
-    except Exception as e:
-        asg.complete_lifecycle_action(
-            LifecycleHookName=lifecycle_hook_name,
-            AutoScalingGroupName=asg_group_name,
-            LifecycleActionResult='ABANDON',
-            InstanceId=ec2_instance_id,
-            LifecycleActionToken=lifecycle_action_token
-        )
-
-        print(f"Error handling lifecycle hook: {e}")
-                """
-            ),
-            handler="index.handler",
-            timeout=Duration.seconds(  # additional 300 seconds is for the lambda running time
-                self._pool.gracetime_period * 60 + 300
-            ),
-            runtime=_lambda.Runtime.PYTHON_3_9,
-            role=self.lifecycle_hook_execution_role,
-            environment={  # pass the gracetime as an environment variable
-                "GRACETIME": str(self._pool.gracetime_period * 60)
-            },
-        )
-        return lifecycle_hook_function
 
     def _add_login_nodes_pool_launch_template(self):
         login_nodes_pool_lt_security_groups = get_login_nodes_security_groups_full(
@@ -238,46 +175,13 @@ nohup /opt/parallelcluster/scripts/daemon_script.sh > /var/log/daemon_script.log
         return auto_scaling_group
 
     def _add_lifecycle_hook(self, auto_scaling_group):
-        self.lifecycle_hook_execution_role = self._get_iam_role()
-        self.lifecycle_hook_function = self._add_lifecycle_hook_lambda()
-
-        lifecycle_topic = sns.Topic(self, "lifecycleTopic")
-        lifecycle_topic.add_subscription(subscriptions.LambdaSubscription(self.lifecycle_hook_function))
-
         return autoscaling.CfnLifecycleHook(
             self,
             "LoginNodesASGLifecycleHook",
             auto_scaling_group_name=auto_scaling_group.ref,
             lifecycle_transition="autoscaling:EC2_INSTANCE_TERMINATING",
-            notification_target_arn=lifecycle_topic.topic_arn,
-            role_arn=self.lifecycle_hook_execution_role.role_arn,
+            heartbeat_timeout=self._pool.gracetime_period * 60,
         )
-
-    def _get_iam_role(self):
-        role = iam.Role(
-            self,
-            "LifecycleHookExecutionRole",
-            assumed_by=iam.CompositePrincipal(
-                iam.ServicePrincipal("lambda.amazonaws.com"),
-                iam.ServicePrincipal("autoscaling.amazonaws.com"),
-            ),
-        )
-        role.add_to_policy(
-            iam.PolicyStatement(
-                resources=["*"],
-                actions=[
-                    "autoscaling:CompleteLifecycleAction",
-                    "autoscaling:RecordLifecycleActionHeartbeat",
-                    "logs:CreateLogGroup",
-                    "logs:CreateLogStream",
-                    "logs:PutLogEvents",
-                    "lambda:InvokeFunction",
-                    "sns:Publish",
-                ],
-            )
-        )
-
-        return role
 
     def _add_login_nodes_pool_target_group(self):
         return elbv2.NetworkTargetGroup(


### PR DESCRIPTION
… because it has a timeout limitation of 15 minutes so that if the grace time is longer than 15 minutes, the lambda function will time out. And instead of it, set heartbeat_timeout as gracetime_period to let instance to wait for grace time. remove the repeatedly alert user the instance is going to be terminated in termination script to avoid annoy user
